### PR TITLE
string.h: solve __write_overflow declared with attribute error

### DIFF
--- a/include/linux/string.h
+++ b/include/linux/string.h
@@ -175,10 +175,15 @@ void __read_overflow2(void) __compiletime_error("detected read beyond size of ob
 void __write_overflow(void) __compiletime_error("detected write beyond size of object passed as 1st parameter");
 
 #if !defined(__NO_FORTIFY) && defined(__OPTIMIZE__) && defined(CONFIG_FORTIFY_SOURCE)
+
+#define __constant_argument(arg) \
+	__builtin_choose_expr(__builtin_constant_p(arg), (arg), 0)
+
 __FORTIFY_INLINE char *strncpy(char *p, const char *q, __kernel_size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
-	if (__builtin_constant_p(size) && p_size < size)
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
 		__write_overflow();
 	if (p_size < size)
 		fortify_panic(__func__);
@@ -229,7 +234,8 @@ __FORTIFY_INLINE size_t strlcpy(char *p, const char *q, size_t size)
 	ret = strlen(q);
 	if (size) {
 		size_t len = (ret >= size) ? size - 1 : ret;
-		if (__builtin_constant_p(len) && len >= p_size)
+		size_t constlen = __constant_argument(len);
+		if (constlen >= p_size)
 			__write_overflow();
 		if (len >= p_size)
 			fortify_panic(__func__);
@@ -259,7 +265,8 @@ __FORTIFY_INLINE char *strncat(char *p, const char *q, __kernel_size_t count)
 __FORTIFY_INLINE void *memset(void *p, int c, __kernel_size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
-	if (__builtin_constant_p(size) && p_size < size)
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
 		__write_overflow();
 	if (p_size < size)
 		fortify_panic(__func__);
@@ -270,12 +277,11 @@ __FORTIFY_INLINE void *memcpy(void *p, const void *q, __kernel_size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
 	size_t q_size = __builtin_object_size(q, 0);
-	if (__builtin_constant_p(size)) {
-		if (p_size < size)
-			__write_overflow();
-		if (q_size < size)
-			__read_overflow2();
-	}
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
+		__write_overflow();
+	if (q_size < constsize)
+		__read_overflow2();
 	if (p_size < size || q_size < size)
 		fortify_panic(__func__);
 	return __builtin_memcpy(p, q, size);
@@ -285,12 +291,11 @@ __FORTIFY_INLINE void *memmove(void *p, const void *q, __kernel_size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
 	size_t q_size = __builtin_object_size(q, 0);
-	if (__builtin_constant_p(size)) {
-		if (p_size < size)
-			__write_overflow();
-		if (q_size < size)
-			__read_overflow2();
-	}
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
+		__write_overflow();
+	if (q_size < constsize)
+		__read_overflow2();
 	if (p_size < size || q_size < size)
 		fortify_panic(__func__);
 	return __builtin_memmove(p, q, size);
@@ -300,7 +305,8 @@ extern void *__real_memscan(void *, int, __kernel_size_t) __RENAME(memscan);
 __FORTIFY_INLINE void *memscan(void *p, int c, __kernel_size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
-	if (__builtin_constant_p(size) && p_size < size)
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
 		__read_overflow();
 	if (p_size < size)
 		fortify_panic(__func__);
@@ -311,12 +317,11 @@ __FORTIFY_INLINE int memcmp(const void *p, const void *q, __kernel_size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
 	size_t q_size = __builtin_object_size(q, 0);
-	if (__builtin_constant_p(size)) {
-		if (p_size < size)
-			__read_overflow();
-		if (q_size < size)
-			__read_overflow2();
-	}
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
+		__read_overflow();
+	if (q_size < constsize)
+		__read_overflow2();
 	if (p_size < size || q_size < size)
 		fortify_panic(__func__);
 	return __builtin_memcmp(p, q, size);
@@ -325,7 +330,8 @@ __FORTIFY_INLINE int memcmp(const void *p, const void *q, __kernel_size_t size)
 __FORTIFY_INLINE void *memchr(const void *p, int c, __kernel_size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
-	if (__builtin_constant_p(size) && p_size < size)
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
 		__read_overflow();
 	if (p_size < size)
 		fortify_panic(__func__);
@@ -336,7 +342,8 @@ void *__real_memchr_inv(const void *s, int c, size_t n) __RENAME(memchr_inv);
 __FORTIFY_INLINE void *memchr_inv(const void *p, int c, size_t size)
 {
 	size_t p_size = __builtin_object_size(p, 0);
-	if (__builtin_constant_p(size) && p_size < size)
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
 		__read_overflow();
 	if (p_size < size)
 		fortify_panic(__func__);
@@ -347,7 +354,8 @@ extern void *__real_kmemdup(const void *src, size_t len, gfp_t gfp) __RENAME(kme
 __FORTIFY_INLINE void *kmemdup(const void *p, size_t size, gfp_t gfp)
 {
 	size_t p_size = __builtin_object_size(p, 0);
-	if (__builtin_constant_p(size) && p_size < size)
+	size_t constsize = __constant_argument(size);
+	if (p_size < constsize)
 		__read_overflow();
 	if (p_size < size)
 		fortify_panic(__func__);


### PR DESCRIPTION
Solve '__write_overflow' declared with attribute error: detected write beyond size of object passed as 1st parameter __write_overflow(); issue by modifying include/Linux/string.h referring to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72785 .

Signed-off-by: Jun ASAKA <JunASAKA@zzy040330.cn>